### PR TITLE
Refactor observations function

### DIFF
--- a/dass/utils.py
+++ b/dass/utils.py
@@ -27,34 +27,24 @@ def observations(
         Function that takes a single argument (the true field value) and returns
         a value to be used as the standard deviation of the noise.
     """
-    d = pd.DataFrame(
-        {
-            "k": pd.Series(dtype=int),
-            "x": pd.Series(dtype=int),
-            "y": pd.Series(dtype=int),
-            "value": pd.Series(dtype=float),
-            "sd": pd.Series(dtype=float),
-        }
-    )
-
     # Create dataframe with observations and necessary meta data.
+    observations = []
     for coordinate in coordinates:
         for k in times:
             value = field[k, coordinate.x, coordinate.y]
             sd = error(value)
-            _df = pd.DataFrame(
-                {
-                    "k": [k],
-                    "x": [coordinate.x],
-                    "y": [coordinate.y],
-                    "value": [value + rng.normal(loc=0.0, scale=sd)],
-                    "sd": [sd],
-                }
+            observations.append(
+                pd.DataFrame(
+                    {
+                        "k": [k],
+                        "x": [coordinate.x],
+                        "y": [coordinate.y],
+                        "value": [value + rng.normal(loc=0.0, scale=sd)],
+                        "sd": [sd],
+                    }
+                )
             )
-            d = pd.concat([d, _df])
-    d = d.set_index(["k", "x", "y"], verify_integrity=True)
-
-    return d
+    return pd.concat(observations).set_index(["k", "x", "y"], verify_integrity=True)
 
 
 def colorbar(mappable):


### PR DESCRIPTION
I haven't tested this beyond using it during EDC2023 yet, but I thought it would a bit simpler to avoid reassigning to temporary variables in the observations function. 